### PR TITLE
Asb tutorial roadblocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 Rplots.pdf
 # R history
 .Rhistory
+# MacOs
+.DS_Store

--- a/Tutorial_Instructions/breakout_1.md
+++ b/Tutorial_Instructions/breakout_1.md
@@ -52,8 +52,11 @@ Open Git Bash and navigate to the `Desktop` folder by using the `cd` (change dir
 ```
 $ cd Desktop
 ```
-*If you're having trouble navigating into your Desktop folder, ask for help from the Tutorial Team. This process can
-vary depending on operating system, spaces in folder names, and version of Git Bash.*
+*If you're having trouble navigating into your Desktop folder, it may be possible that your desktop folder is located
+ on a different hard drive (like OneNote). Windows users can open file explorer, right click on the file they'd like
+ to clone the repo into, and select `Git Bash Here`. This effectively sets the current directory in Git Bash. You can 
+ also ask for help from the Tutorial Team. This process can vary depending on operating system, spaces in folder names, 
+ and version of Git Bash.*
 
 Now you can clone the remote repository from GitHub.com to your `Desktop` folder. `URL` is the repository of
 the group leader and will include his or her username. It should be like `https://github.com/GROUP-LEADER-USERNAME/ASB_Tutorial`.

--- a/Tutorial_Instructions/breakout_1.md
+++ b/Tutorial_Instructions/breakout_1.md
@@ -135,7 +135,10 @@ without internet access to GitHub because you have a local copy of the repositor
 convenient, you can send all your commits to the repository on GitHub. This process is called *pushing* commits from a 
 local repository to the remote repository.
 
-To push commits to your remote repository on GitHub, run: 
+To push commits to your remote repository on GitHub, run:
+
+*The first time you push to a repository, Git Bash or Terminal may request that you login to your github account at this
+time. Enter your username and password and press Enter.* 
 ```
 $ git push 
 ```


### PR DESCRIPTION
after running through the tutorial with 60 attendees, this PR addresses the issues some groups ran into. Mostly `breakout_1.md` instructions were adjusted, but also added a file to the `gitignore` list.